### PR TITLE
[DX] Enhance readability `response header "foo" should have value "chuck"`

### DIFF
--- a/src/RestApiContext.php
+++ b/src/RestApiContext.php
@@ -107,9 +107,19 @@ class RestApiContext extends BehatContext implements JsonStorageAware
      */
     public function theResponseHeaderShouldHave($headerKey, $expectedValue)
     {
-        if (! $this->response->getHeader($headerKey)->hasValue($expectedValue)) {
-            throw new \mageekguy\atoum\asserter\exception($this->asserter, sprintf('Header "%s" is not containing "%s" in last response.', $headerKey, $expectedValue));
-        }
+        $hasValue = $this->response->getHeader($headerKey)->hasValue($expectedValue);
+        $this->asserter->boolean($hasValue)
+            ->isTrue(
+                sprintf(
+                    'Header "%s" is not containing in last response:
+"%s"
+Received:
+"%s"',
+                    $headerKey,
+                    $expectedValue,
+                    implode(', ', $this->response->getHeader($headerKey)->toArray())
+                )
+            );
     }
 
     /**

--- a/tests/Units/RestApiContext.php
+++ b/tests/Units/RestApiContext.php
@@ -97,6 +97,15 @@ class RestApiContext extends atoum
                 $sut->theResponseHeaderShouldHave('foo', 'chuck');
             }
         )->isInstanceOf('\mageekguy\atoum\asserter\exception')
+            ->hasMessage('Header "foo" is not containing in last response:
+"chuck"
+Received:
+"bar, azerty"
+-Expected
++Actual
+@@ -1 +1 @@
+-bool(true)
++bool(false)')
         ;
     }
 


### PR DESCRIPTION
This step 

```gherkin
the response header "foo" should have value "chuck"
```

When failing will render a more readable error message

```
 Header "foo" is not containing in last response:
      "chuck"
      Received:
      "bar, azerty"
```

It shall be easier to debug.