### PR TITLE
Allow external Guzzle Response injection

### DIFF
--- a/src/Rest/RestApiBrowser.php
+++ b/src/Rest/RestApiBrowser.php
@@ -5,6 +5,7 @@ namespace Rezzza\RestApiBehatExtension\Rest;
 use Guzzle\Http\Exception\BadResponseException;
 use Guzzle\Http\ClientInterface as HttpClient;
 use Guzzle\Http\Message\Response;
+use Behat\Gherkin\Node\PyStringNode;
 
 class RestApiBrowser
 {
@@ -110,6 +111,12 @@ class RestApiBrowser
         }
     }
 
+    /**
+     * @return HttpClient
+     */
+    public function getHttpClient(){
+        return $this->httpClient;
+    }
     /**
      * @param string                $method
      * @param string                $uri With or without host

--- a/src/Rest/RestApiBrowser.php
+++ b/src/Rest/RestApiBrowser.php
@@ -4,6 +4,7 @@ namespace Rezzza\RestApiBehatExtension\Rest;
 
 use Guzzle\Http\Exception\BadResponseException;
 use Guzzle\Http\ClientInterface as HttpClient;
+use Guzzle\Http\Message\Request;
 
 class RestApiBrowser
 {
@@ -96,6 +97,17 @@ class RestApiBrowser
     {
         $this->removeRequestHeader($name);
         $this->addRequestHeader($name, $value);
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+        if (null !== $this->responseStorage) {
+            $this->responseStorage->writeRawContent($this->response->getBody(true));
+        }
     }
 
     /**

--- a/src/Rest/RestApiBrowser.php
+++ b/src/Rest/RestApiBrowser.php
@@ -4,7 +4,7 @@ namespace Rezzza\RestApiBehatExtension\Rest;
 
 use Guzzle\Http\Exception\BadResponseException;
 use Guzzle\Http\ClientInterface as HttpClient;
-use Guzzle\Http\Message\Request;
+use Guzzle\Http\Message\Response;
 
 class RestApiBrowser
 {

--- a/src/Rest/RestApiBrowser.php
+++ b/src/Rest/RestApiBrowser.php
@@ -112,12 +112,6 @@ class RestApiBrowser
     }
 
     /**
-     * @return HttpClient
-     */
-    public function getHttpClient(){
-        return $this->httpClient;
-    }
-    /**
      * @param string                $method
      * @param string                $uri With or without host
      * @param string|resource|array $body


### PR DESCRIPTION
As it was posible in the JsonContext to inject external JSON accessing the Inspector to third party Context, was impossible to inject a Response when for to obtain it is more complex than a simple array of strings    
(Ex. multipart with files) , even having access to RestApiBrowser. 
This small change delegates the "breaking" of the Rest rules , than time to time in real world APIs happens, to third party Context but still allow to use proper check code and the json validations steps without need to reimplement them.