### PR TITLE
Add context text to expectation exception

### DIFF
--- a/src/ExpectationFailed.php
+++ b/src/ExpectationFailed.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rezzza\RestApiBehatExtension;
+
+abstract class ExpectationFailed extends \Exception
+{
+    abstract function getContextText();
+
+    /**
+     * Returns exception message with additional context info.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        try {
+            $contextText = $this->pipeString($this->trimString($this->getContextText())."\n");
+            $string = sprintf("%s\n\n%s", $this->getMessage(), $contextText);
+        } catch (\Exception $e) {
+            return $this->getMessage();
+        }
+
+        return $string;
+    }
+
+    /**
+     * Prepends every line in a string with pipe (|).
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    protected function pipeString($string)
+    {
+        return '|  '.strtr($string, array("\n" => "\n|  "));
+    }
+
+    /**
+     * Trims string to specified number of chars.
+     *
+     * @param string $string response content
+     * @param int    $count  trim count
+     *
+     * @return string
+     */
+    protected function trimString($string, $count = 1000)
+    {
+        $string = trim($string);
+        if ($count < mb_strlen($string)) {
+            return mb_substr($string, 0, $count - 3).'...';
+        }
+
+        return $string;
+    }
+}

--- a/src/Json/WrongJsonExpectation.php
+++ b/src/Json/WrongJsonExpectation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rezzza\RestApiBehatExtension\Json;
+
+use Rezzza\RestApiBehatExtension\ExpectationFailed;
+
+class WrongJsonExpectation extends ExpectationFailed
+{
+    private $json;
+
+    public function __construct($message, Json $json, $previous = null)
+    {
+        $this->json = $json;
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getContextText()
+    {
+        return $this->json->encode(true);
+    }
+}

--- a/src/Rest/HttpExchangeFormatter.php
+++ b/src/Rest/HttpExchangeFormatter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rezzza\RestApiBehatExtension\Rest;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+
+class HttpExchangeFormatter
+{
+    private $request;
+
+    private $response;
+
+    public function __construct(RequestInterface $request, ResponseInterface $response)
+    {
+        $this->request = $request;
+        $this->response = $response;
+    }
+
+    public function formatRequest()
+    {
+        return sprintf(
+            "%s %s :\n%s%s\n",
+            $this->request->getMethod(),
+            $this->request->getUri(),
+            $this->getRawHeaders($this->request->getHeaders()),
+            $this->request->getBody()
+        );
+    }
+
+    public function formatFullExchange()
+    {
+        return sprintf(
+            "%s %s :\n%s %s\n%s%s\n",
+            $this->request->getMethod(),
+            $this->request->getUri()->__toString(),
+            $this->response->getStatusCode(),
+            $this->response->getReasonPhrase(),
+            $this->getRawHeaders($this->response->getHeaders()),
+            $this->response->getBody()
+        );
+    }
+
+    /**
+     * @param array $headers
+     * @return string
+     */
+    private function getRawHeaders(array $headers)
+    {
+        $rawHeaders = '';
+        foreach ($headers as $key => $value) {
+            $rawHeaders .= sprintf("%s: %s\n", $key, is_array($value) ? implode(", ", $value) : $value);
+        }
+        $rawHeaders .= "\n";
+
+        return $rawHeaders;
+    }
+}

--- a/src/Rest/ResponseStorage.php
+++ b/src/Rest/ResponseStorage.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Rest;
-
 namespace Rezzza\RestApiBehatExtension\Rest;
 
 interface ResponseStorage

--- a/src/Rest/WrongResponseExpectation.php
+++ b/src/Rest/WrongResponseExpectation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rezzza\RestApiBehatExtension\Rest;
+
+use Rezzza\RestApiBehatExtension\ExpectationFailed;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+
+class WrongResponseExpectation extends ExpectationFailed
+{
+    private $request;
+
+    private $response;
+
+    public function __construct($message, RequestInterface $request, ResponseInterface $response, $previous = null)
+    {
+        $this->request = $request;
+        $this->response = $response;
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getContextText()
+    {
+        $formatter = new HttpExchangeFormatter($this->request, $this->response);
+
+        return $formatter->formatFullExchange();
+    }
+}

--- a/tests/Units/Json/WrongJsonExpectation.php
+++ b/tests/Units/Json/WrongJsonExpectation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rezzza\RestApiBehatExtension\Tests\Units\Json;
+
+use atoum;
+
+class WrongJsonExpectation extends atoum
+{
+    public function test_it_display_pretty_json_when_cast_to_string()
+    {
+        $this
+            ->given(
+                $json = new \Rezzza\RestApiBehatExtension\Json\Json('{"foo":"bar"}'),
+                $this->newTestedInstance('Error', $json)
+            )
+            ->when(
+                $result = $this->testedInstance->__toString()
+            )
+            ->then
+                ->string($result)
+                    ->contains(<<<EOF
+|  {
+|      "foo": "bar"
+|  }
+EOF
+                    )
+        ;
+    }
+}

--- a/tests/Units/Json/WrongResponseExpectation.php
+++ b/tests/Units/Json/WrongResponseExpectation.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rezzza\RestApiBehatExtension\Tests\Units\Rest;
+
+use atoum;
+
+class WrongResponseExpectation extends atoum
+{
+    public function test_it_display_pretty_response_when_cast_to_string()
+    {
+        $this
+            ->given(
+                $uri = new \mock\Psr\Http\Message\UriInterface,
+                $this->calling($uri)->__toString = 'http://test.com/foo',
+                $request = new \mock\Psr\Http\Message\RequestInterface,
+                $this->calling($request)->getMethod = 'GET',
+                $this->calling($request)->getUri = $uri,
+                $response = new \mock\Psr\Http\Message\ResponseInterface,
+                $this->calling($response)->getStatusCode = 200,
+                $this->calling($response)->getReasonPhrase = 'OK',
+                $this->calling($response)->getHeaders = ['Content-Type' => 'application/json'],
+                $this->calling($response)->getBody = '{"status":"ok"}',
+                $this->newTestedInstance('Error', $request, $response)
+            )
+            ->when(
+                $result = $this->testedInstance->__toString()
+            )
+            ->then
+                ->string($result)
+                    ->contains(<<<EOF
+|  GET http://test.com/foo :
+|  200 OK
+|  Content-Type: application/json
+|  
+|  {"status":"ok"}
+EOF
+                    )
+        ;
+    }
+}


### PR DESCRIPTION
- When JSON assertion fail we display now in the exception, the json received
- When HTTP assertion fail we display the requestion/response formatted (like in printResponse)

fix #47