### PR TITLE
:ambulance: Fix bad namespace usage of an exception class.

### DIFF
--- a/src/RestApiContext.php
+++ b/src/RestApiContext.php
@@ -60,7 +60,7 @@ class RestApiContext implements Context, SnippetAcceptingContext
         try {
             $this->asserter->variable($actual)->isEqualTo($expected);
         } catch (\Exception $e) {
-            throw new WrongResponseExpectation($e->getMessage(), $this->restApiBrowser->getRequest(), $this->getResponse(), $e);
+            throw new Rest\WrongResponseExpectation($e->getMessage(), $this->restApiBrowser->getRequest(), $this->getResponse(), $e);
         }
     }
 


### PR DESCRIPTION
Fixes #60 