### PR TITLE
truncate request headers after sending.

### DIFF
--- a/src/Rest/RestApiBrowser.php
+++ b/src/Rest/RestApiBrowser.php
@@ -101,6 +101,7 @@ class RestApiBrowser
 
         $this->request = $this->messageFactory->createRequest($method, $uri, $this->requestHeaders, $body);
         $this->response = $this->httpClient->sendRequest($this->request);
+        $this->requestHeaders = [];
 
         if (null !== $this->responseStorage) {
             $this->responseStorage->writeRawContent((string) $this->response->getBody());


### PR DESCRIPTION
Earlier versions of this project cleared the request headers after sending, but this essential
functionality was removed in a merge that was apparently about a separate issue. Does that
mean it was an accident?

https://github.com/rezzza/rest-api-behat-extension/commit/2b10927c10e2eb531480c427a4750413823d0fab#diff-9d1a35b8dac9c540c2aedf7c51d8e7e7L135

The alternative is to move the request headers into the context, which is also a good idea, but it's
a big BC break.

https://github.com/rezzza/rest-api-behat-extension/pull/65