### PR TITLE
Refine ci to cover php nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 dist: trusty
+cache:
+    directories:
+        - vendor
 php:
     - 5.6
     - 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,35 @@
 language: php
+dist: trusty
+php:
+    - 5.6
+    - 7
+    - 7.1
+    - nightly
+env:
+    matrix:
+        - COMPOSER_PREFER="--prefer-stable"
+        - COMPOSER_PREFER="--prefer-lowest"
 matrix:
-    include:
+    allow_failures:
         -
-            php: 5.6
-        -
-            php: 7
-        -
-            php: 7.1
-            env: deps=low-json-schema
-        -
-            php: 7.1
-            env: deps=high-json-schema
+            php: nightly
+    fast_finish: true
 before_script:
     - >-
-        git clone --branch trusty --depth=1
-        https://github.com/rezzza/travis-ci.git ~/.rezzza.travis-ci
-    - ~/.rezzza.travis-ci/php/bootstrap.sh
-    - composer global require hirak/prestissimo
-    - composer install
+        echo 'always_populate_raw_post_data = -1' >> ~/.phpenv/versions/$(phpenv
+        version-name)/etc/conf.d/travis.ini
     - |
-        if [[ $deps = low-json-schema ]] ; then
-            composer update --prefer-lowest --prefer-stable justinrainbow/json-schema
+        if [ ! $(php -m | grep -ci xdebug) -eq 0 ] ; then
+            phpenv config-rm xdebug.ini
+        fi
+    - composer global require hirak/prestissimo
+    - composer update $COMPOSER_PREFER
+    - |
+        # We force latest atoum on php >=7
+        if [ $(php -r 'echo phpversion();' | sed -e 's/\..*//g') -eq 7 ] ; then
+            composer update --prefer-stable atoum/atoum
         fi
     - 'php -S 127.0.0.1:8888 -t "$TRAVIS_BUILD_DIR/www" &> /dev/null &'
 script:
-    - bin/atoum -ulr
-    - bin/behat -f progress
+    - vendor/bin/atoum -ulr
+    - vendor/bin/behat -f progress

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": ">=5.6.0",
         "behat/behat": "~3.0",
         "atoum/atoum": "~1.0|~2.0|~3.0|3.0.x-dev",
-        "symfony/property-access": "~2.4|~3.0",
-        "justinrainbow/json-schema": ">=3.0 <=6.0",
+        "symfony/property-access": "~2.5|~3.0",
+        "justinrainbow/json-schema": ">=3.0 <6.0",
         "psr/http-message": "^1.0",
         "php-http/discovery": "^1.0",
         "php-http/client-common": "^1.2",
@@ -36,7 +36,6 @@
         "php-http/mock-client": "^0.3.2"
     },
     "config": {
-        "bin-dir": "bin/",
         "optimize-autoloader": true,
         "preferred-install": {
             "*": "dist"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -97,7 +97,8 @@ class FeatureContext implements Context, SnippetAcceptingContext
             throw new \LogicException('Accepts only "fail" or "pass"');
         }
 
-        $this->asserter->phpString($this->getOutput())->contains((string) $string);
+        $stringAsserterFunc = class_exists('mageekguy\\atoum\\asserters\\phpString') ? 'phpString' : 'string';
+        $this->asserter->$stringAsserterFunc($this->getOutput())->contains((string) $string);
     }
 
     private function getExitCode()

--- a/tests/Units/Json/Json.php
+++ b/tests/Units/Json/Json.php
@@ -67,6 +67,7 @@ class Json extends atoum
 
     public function test_should_read_valid_expression()
     {
+        $stringAsserterFunc = class_exists('mageekguy\\atoum\\asserters\\phpString') ? 'phpString' : 'string';
         $this
             ->given(
                 $accessor = PropertyAccess::createPropertyAccessor(),
@@ -75,7 +76,7 @@ class Json extends atoum
             ->when(
                 $result = $sut->read('foo', $accessor)
             )
-                ->phpString($result)
+                ->$stringAsserterFunc($result)
                     ->isEqualTo('bar')
         ;
     }


### PR DESCRIPTION
As we put behind `symfony/property-access` 2.4.X we probably need to bump minor to 6.1 after this PR get merged.