### PR TITLE
Upgrade Silex to version 2.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "mtdowling/jmespath.php": "^2.3"
     },
     "require-dev": {
-        "silex/silex": "~1.0",
+        "silex/silex": "~2.0",
         "symfony/process": "~2.1|~3.0",
         "guzzlehttp/psr7": "^1.3",
         "php-http/curl-client": "^1.5",


### PR DESCRIPTION
Silex 1.0 is no longer maintained and holds back some of the other developer dependencies from
being updated.
